### PR TITLE
Update _brand.yml typography to Open Sans and Roboto Slab

### DIFF
--- a/_brand.yml
+++ b/_brand.yml
@@ -27,7 +27,24 @@ color:
   primary: su-yellow
   secondary: dark-grey   
   info: su-blue
-  
+
 typography:
+  fonts:
+    - family: "Roboto Slab"
+      weights: [300, 700]
+    - family: "Open Sans"
+      weights: [400, 600, 700]
+
+  base:
+    family: "Open Sans"
+    weight: 400
+
+  headings:
+    family: "Roboto Slab"
+    weight: 700
+
   link:
     color: info
+
+  strong:
+    weight: 700


### PR DESCRIPTION
Update _brand.yml so Quarto and Shiny consumers using YAML receive the same typography standard as the TOML brand definition.

Changes  
- Declared font families and weights  Open Sans: 400, 600, 700  
- Roboto Slab: 300, 700  
- Set base typography defaults to Open    Sans 400  
- Set headings typography defaults to Roboto Slab 700  
- Preserved link colour mapping to info