### PR TITLE
Switch SU stylesheet fonts to Open Sans body and Roboto Slab headings

### DIFF
--- a/_SUBrand.StyleSheet.css
+++ b/_SUBrand.StyleSheet.css
@@ -1,7 +1,15 @@
-@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap');
+@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@400;600;700&family=Roboto+Slab:wght@300;700&display=swap");
 
 body {
-  font-family: 'Roboto', Arial, sans-serif;
+  font-family: "Open Sans", Arial, sans-serif;
+  font-weight: 400;
+}
+
+h1, h2, h3, h4, h5, h6,
+.home h1, .home h2, .home h3 {
+  font-family: "Roboto Slab", "Open Sans", Arial, sans-serif;
+  font-weight: 700;
+  text-align: center;
 }
 
 :root {
@@ -54,10 +62,6 @@ body,
 }
 
 .center {
-  text-align: center;
-}
-
-.home h1, .home h2, .home h3 {
   text-align: center;
 }
 


### PR DESCRIPTION
Update the SU stylesheet to load Open Sans and Roboto Slab from Google Fonts and apply them to body text and headings.

Changes  
- Replaced Google Fonts import to load - Open Sans (400/600/700) and Roboto Slab (300/700)  
- Updated body to use Open Sans (default 400)  
- Added heading rules to use Roboto Slab (700)